### PR TITLE
Color customization + Minor changes/fixes

### DIFF
--- a/code/p3rpc.femc/p3rpc.femc/Components/Camp.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/Camp.cs
@@ -2404,12 +2404,12 @@ namespace p3rpc.femc.Components
 
         private unsafe FSprColor GetMatchingColorForEntry(int entryId)
         {
-            if (entryId % 3 == 0) return ConfigColor.ToFSprColor(_context._config.CampMenuItemColor1);
-            else if (entryId % 3 == 1) return ConfigColor.ToFSprColor(_context._config.CampMenuItemColor2);
-            else /*(entryId % 3 == 2)*/ return ConfigColor.ToFSprColor(_context._config.CampMenuItemColor3);
+            if (entryId % 3 == 0) return ConfigColor.ToFSprColor(_context._config.CampMenuSystemItemColor1);
+            else if (entryId % 3 == 1) return ConfigColor.ToFSprColor(_context._config.CampMenuSystemItemColor2);
+            else /*(entryId % 3 == 2)*/ return ConfigColor.ToFSprColor(_context._config.CampMenuSystemItemColor3);
         }
 
-        private unsafe FSprColor UCmpSystemDraw_GetMenuColorNoSelectImpl() => ConfigColor.ToFSprColor(_context._config.CampMenuItemColorNoSel);
+        private unsafe FSprColor UCmpSystemDraw_GetMenuColorNoSelectImpl() => ConfigColor.ToFSprColor(_context._config.CampMenuSystemItemColorNoSel);
 
         private unsafe void UCmpSystemDraw_DrawUnhighlightedMenuOptionsImpl(UCmpSystemDraw* self, UCmpSystemSystem* sys, uint activeId, uint queueId)
         {

--- a/code/p3rpc.femc/p3rpc.femc/Components/PersonaStatus.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/PersonaStatus.cs
@@ -833,7 +833,8 @@ namespace p3rpc.femc.Components
                 _uiCommon._drawSpr(&self->baseObj.drawer, statIconPosLayout.X, statIconPosLayout.Y, 0, &statIconShadowCol, (uint)(i + 0x1bf), 1, 1, Angle, campSpr, EUI_DRAW_POINT.UI_DRAW_CENTER_CENTER, self->baseObj.QueueId);
                 var statIconFillCol = new FColor(0xcc, 0x0, 0x0, 0x0);
                 _uiCommon._drawSpr(&self->baseObj.drawer, statIconPosLayout.X, statIconPosLayout.Y, 0, &statIconFillCol, (uint)(i + 0x1ba), 1, 1, Angle, campSpr, EUI_DRAW_POINT.UI_DRAW_CENTER_CENTER, self->baseObj.QueueId);
-                var personaStatLevelColor = baseLvl < baseAndNextLvl ? nextLevelColor : ConfigColor.ToFColorBP(_context.ColorWhite);
+                var personaCombineStatGrowth = self->GetCombinePersonaStatGrowth(i);
+                var personaStatLevelColor = (baseLvl < baseAndNextLvl || personaCombineStatGrowth != 0) ? nextLevelColor : ConfigColor.ToFColorBP(_context.ColorWhite);
                 string personaStatLevelStr = $"{(int)baseStatDisplay}";
                 for (int j = 0; j < personaStatLevelStr.Length; j++)
                 {
@@ -844,7 +845,7 @@ namespace p3rpc.femc.Components
                 _uiCommon._drawSpr(&self->baseObj.drawer, statIconPos.X + 251, statIconPos.Y - 40, 0, &barShadowColor, 0x1c9, 1, 1, Angle - 11, campSpr, EUI_DRAW_POINT.UI_DRAW_CENTER_CENTER, self->baseObj.QueueId);
                 var barContentColor = ConfigColor.ToFColorBP(_context._config.PersonaStatusSkillListCheckboardAlt);
                 _uiCommon._drawSpr(&self->baseObj.drawer, statIconPos.X + 234, statIconPos.Y - 45, 0, &barContentColor, 0x1c9, 1, 1, Angle - 11, campSpr, EUI_DRAW_POINT.UI_DRAW_CENTER_CENTER, self->baseObj.QueueId);
-                if (baseLvl < baseAndEquipLvl) // draw next level stat increase
+                if (baseLvl < baseAndNextLvl) // draw next level stat increase
                 {
                     var nf1 = UICommon.Lerp(baseAndEquipLvl * switchPersonaStatParamTrans, (baseAndEquipLvl + nextLvlBonus) * switchPersonaStatParamTrans, f4);
                     var nf2 = UICommon.ProgressTrackFraction(nf1, 0, 99, 0);

--- a/code/p3rpc.femc/p3rpc.femc/Config.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Config.cs
@@ -2492,6 +2492,22 @@ namespace p3rpc.femc.Configuration
         [DisplayName("Camp: Item Effect font color")]
         public ConfigColor CampItemEffectFont { get; set; } = ConfigColor.MellodiColorDark3;
 
+        [DisplayName("Camp: System Menu Item Color 1")]
+        [Category("UI Colors")]
+        public ConfigColor CampMenuSystemItemColor1 { get; set; } = ConfigColor.CampMenuItemColor1;
+
+        [DisplayName("Camp: System Menu Item Color 2")]
+        [Category("UI Colors")]
+        public ConfigColor CampMenuSystemItemColor2 { get; set; } = ConfigColor.CampMenuItemColor2;
+
+        [DisplayName("Camp: System Menu Item Color 3")]
+        [Category("UI Colors")]
+        public ConfigColor CampMenuSystemItemColor3 { get; set; } = ConfigColor.CampMenuItemColor3;
+
+        [DisplayName("Camp: System Menu Item Color No Select")]
+        [Category("UI Colors")]
+        public ConfigColor CampMenuSystemItemColorNoSel { get; set; } = ConfigColor.CampMenuItemColorNoSel;
+
         /*[DisplayName("Draw Original Select Box")]
         [Category("Debug")]
         [Display(Order = 1)]

--- a/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
+++ b/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="p3rpc.commonmodutils" Version="1.7.0" />
-    <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.7.2" />
+    <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.7.3" />
     <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
     <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0" />
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />


### PR DESCRIPTION
Camp menu:
- Added separated colors for unhighlighted item menu options, 4 colors for camp high (camp root) and another 4 colors for camp low (system options) allowing more customization

Persona Status:
- Added glowing yellow effect on stat numbers that will be boosted, just like base game
- Fixed yellow stat growth bars not showing up when persona just leveled up

Backend changes:
- Bump p3rpc.nativetypes to version 1.7.3