### PR TITLE
Re-adding self to the credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pretty much any contribution is welcome! You can check our [wiki](https://github
 
 **Spanish Localization Lead**: kiawaii (Kiara)
 
-**Founding Producer (v1.0.0)**: Fernhw (initial task management)
+**Founding Producer (v1.0.0)**: [fernhw](https://github.com/fernhw)
 
 <br/>
 


### PR DESCRIPTION
Hey Team! 👋

Quick credit restoration.. I chatted with Mudkip on Discord, and he gave the thumbs up to add my name back. Here's what I brought to launch the project:

- **Built this exact README** (and we still use it) 
- **Created & completed 100s of Trello tasks** that got us to 1.0.0  
  - This includes all graphics, bugs that appeared
  - localization accross several languages
  - Created the spec (google doc with instructions)
  - Kept my cool organizing all language teams, english was completed before I left.
  - I created one of the arts (as a bonus), all out attack win screen of Kotone.
  - I was (don't know if still am) part of the mod team early 2024
  - And we as a group cleaned most of that trello very quick.

Most of the work is beyond the initial scope and its ok.
 
All I ask for and its no big changes. Just adding me as **Founding Producer (v1.0.0)** at the bottom of Leadership. Keeps it real, honors the roots, and celebrates how far we've come to 2.3! 

**Thanks!**
If you need my help on anything I'm (and always **have** been there)