### PR TITLE
Granularly disable modules which were consistently problematic on Linux w/ Deck Compatibility switch

### DIFF
--- a/code/p3rpc.femc/p3rpc.femc/Mod.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Mod.cs
@@ -183,16 +183,16 @@ namespace p3rpc.femc
             _costumeApi.AddCostumesFolder(_modConfig.ModId, Path.Combine(_context._modLocation, "Outfit Loader")); // Folder with all the costume ymls
         }
 
-        private void InitializeModules() // Rirurin's stuff, don't touch on penalty of death (Ivan is exempt from this) 
+		private void InitializeModules() // Rirurin's stuff, don't touch on penalty of death (Ivan is exempt from this) 
 		{
 			_modRuntime.AddModule<UICommon>();
-            _modRuntime.AddModule<FemcEquipment>();
-            if (_configuration.EnableMailIcon) _modRuntime.AddModule<MailIcon>();
-            bool deckCompatibilitySwitch = _configuration.DeckCompatibilitySwitch;
+			_modRuntime.AddModule<FemcEquipment>();
+			if (_configuration.EnableMailIcon) _modRuntime.AddModule<MailIcon>();
+			bool deckCompatibilitySwitch = _configuration.DeckCompatibilitySwitch;
 
-            if (_configuration.EnableCampMenu && !deckCompatibilitySwitch)
-            {
-                _modRuntime.AddModule<CampCommon>();
+			if (_configuration.EnableCampMenu)
+			{
+				_modRuntime.AddModule<CampCommon>();
 				_modRuntime.AddModule<CampRoot>();
 				_modRuntime.AddModule<CampSkill>();
 				_modRuntime.AddModule<CampItem>();
@@ -200,14 +200,19 @@ namespace p3rpc.femc
 				_modRuntime.AddModule<CampPersona>();
 				_modRuntime.AddModule<CampStats>();
 				_modRuntime.AddModule<CampSocialLink>();
-                _modRuntime.AddModule<CampQuest>();
-                _modRuntime.AddModule<CampCalendar>();
-				_modRuntime.AddModule<CampSystem>();
-				_modRuntime.AddModule<SocialStats>();
-				_modRuntime.AddModule<Tutorial>();
-				_modRuntime.AddModule<MissingPerson>();
-                _modRuntime.AddModule<Requests>();
-            }
+				_modRuntime.AddModule<CampQuest>();
+				// Disable loading of these modules when Deck Compatibility is enabled,
+				// as they are consistently problematic and prone to crashes on Linux
+				if (!deckCompatibilitySwitch)
+				{
+					_modRuntime.AddModule<CampCalendar>();
+					_modRuntime.AddModule<CampSystem>();
+					_modRuntime.AddModule<SocialStats>();
+					_modRuntime.AddModule<Tutorial>();
+					_modRuntime.AddModule<MissingPerson>();
+					_modRuntime.AddModule<Requests>();
+				}
+			}
 			if (_configuration.EnableDateTimePanel) _modRuntime.AddModule<DateTimePanel>();
 			if (_configuration.EnableTextbox)
 			{
@@ -224,8 +229,8 @@ namespace p3rpc.femc
 				_modRuntime.AddModule<MsgWindowSelectMind>();
 			}
 			if (_configuration.EnableInteractPrompt) _modRuntime.AddModule<MiscCheckDraw>();
-            if (_configuration.EnableMinimap && !deckCompatibilitySwitch)
-            {
+			if (_configuration.EnableMinimap)
+			{
 				_modRuntime.AddModule<Minimap>();
 				_modRuntime.AddModule<LocationSelect>();
 			}
@@ -239,12 +244,12 @@ namespace p3rpc.femc
 			}
 			if (_configuration.EnableTownMap) _modRuntime.AddModule<TownMap>();
 			if (_configuration.EnablePartyPanel) _modRuntime.AddModule<PartyPanel>();
-            if (_configuration.EnableBattle) _modRuntime.AddModule<Battle>();
-            if (_configuration.EnableBacklog) _modRuntime.AddModule<Backlog>();
+			if (_configuration.EnableBattle) _modRuntime.AddModule<Battle>();
+			if (_configuration.EnableBacklog) _modRuntime.AddModule<Backlog>();
 			if (_configuration.EnableButtonPrompts) _modRuntime.AddModule<KeyHelp>();
 			if (_configuration.EnableGetItem) _modRuntime.AddModule<MiscGetItemDraw>();
-            if (_configuration.EnableTimeSkip && !deckCompatibilitySwitch)
-            {
+			if (_configuration.EnableTimeSkip)
+			{
 				_modRuntime.AddModule<DayChange>();
 				_modRuntime.AddModule<TimeChange>();
 			}
@@ -273,8 +278,8 @@ namespace p3rpc.femc
 			if (_configuration.EnableWipe) _modRuntime.AddModule<Wipe>();
 			if (_configuration.EnableItemList) _modRuntime.AddModule<ItemList>();
 			if (_configuration.EnableCommunity) _modRuntime.AddModule<Cmmu>();
-            _modRuntime.RegisterModules();
-        }
+			_modRuntime.RegisterModules();
+		}
 
 		#region Standard Overrides
 		public override void ConfigurationUpdated(Config configuration)
@@ -284,7 +289,7 @@ namespace p3rpc.femc
 			_configuration = configuration;
 			_logger.WriteLine($"[{_modConfig.ModId}] Config Updated: Applying");
 			_modRuntime.UpdateConfiguration(configuration);
-        }
+		}
 		#endregion
 
 		#region For Exports, Serialization etc.


### PR DESCRIPTION
In my experimentation & testing on Linux (specifically the CachyOS distro), I found that `Enable Minimap` and `Enable Time Skip` seemed to actually work flawlessly at least as of 2.4.0 and didn't need to be forced off with the Deck Compatibility toggle, so I removed the check for that. The following modules under the `Enable Camp Menu` option did still give me crashes consistently however, so I made it so that within that option only they get forced-off with Deck Compatibility on:

* `CampCalendar`
* `CampSystem`
* `SocialStats`
* `Tutorial`
* `MissingPerson`
* `Requests`

The way they cause crashes is interesting as well. If you only have one/some of them to be enabled, the game consistently crashes after the opening FMV full stop, whereas when you enable them all, the game consistently crashes upon interacting with objects (ie the bed in the protag's room) or using the minimap, however the actual menus they affect do otherwise work fine.

It may be possible that only specific code hook(s) within the modules are being problematic and could be disabled within the modules themselves by the compatibility switch, but trying to mess with those is beyond my expertise and amount of time I'm currently willing to spend, so for now I say this is a good compromise as it does get a good amount of the Camp menu to be coloured while being fairly stable in my testing.

(Not to mention that even in the worst-case scenario where this still doesn't work for some users, the checks can always just be added back if need be :3)