### PR TITLE
Set color for Camp Character Outline

### DIFF
--- a/code/p3rpc.femc/p3rpc.femc/Components/Camp.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/Camp.cs
@@ -221,7 +221,18 @@ namespace p3rpc.femc.Components
             ConfigColor.SetColorIgnoreAlpha(ref return_value->NamiTutorialBColor, _context._config.NamiTutorialBColor);
             ConfigColor.SetColorIgnoreAlpha(ref return_value->NamiConfigAColor, _context._config.NamiConfigAColor);
             ConfigColor.SetColorIgnoreAlpha(ref return_value->NamiConfigBColor, _context._config.NamiConfigBColor);
-
+           
+            // character outline color (varies for each menu)
+            ConfigColor.SetColor(ref return_value->Edit_Root_FillColor, _context._config.EditRootFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Skill_FillColor, _context._config.EditSkillFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Item_FillColor, _context._config.EditItemFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Equip_FillColor, _context._config.EditEquipFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Status_FillColor, _context._config.EditStatusFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Quest_FillColor, _context._config.EditQuestFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Commu_FillColor, _context._config.EditCommuFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_System_FillColor, _context._config.EditSystemFillColor);
+            ConfigColor.SetColor(ref return_value->Edit_Config_FillColor, _context._config.EditConfigFillColor);
+            
             return return_value;
         }
         private unsafe FLinearColor* UCmpRootDraw_DrawMenuItems_SetColorsNoSelImpl(byte opacity, FLinearColor* colorOut)

--- a/code/p3rpc.femc/p3rpc.femc/Config.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Config.cs
@@ -2875,6 +2875,33 @@ namespace p3rpc.femc.Configuration
         [DisplayName("Camp System: Tutorial System BG card keyframe 3")]
         public ConfigColor CampTutorialSystemKeyframe3 { get; set; } = new ConfigColor(0x99, 0x33, 0x63, 0xff);
 
+        [DisplayName("Camp Root: Character Outline")]
+        public ConfigColor EditRootFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp Skill: Character Outline")]
+        public ConfigColor EditSkillFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+         
+        [DisplayName("Camp Item: Character Outline")]
+        public ConfigColor EditItemFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp Equip: Character Outline")]
+        public ConfigColor EditEquipFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp Status: Character Outline")]
+        public ConfigColor EditStatusFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp Quest: Character Outline")]
+        public ConfigColor EditQuestFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp Commu: Character Outline")]
+        public ConfigColor EditCommuFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp System: Character Outline")]
+        public ConfigColor EditSystemFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
+        [DisplayName("Camp Config: Character Outline")]
+        public ConfigColor EditConfigFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
+        
         /*[DisplayName("Draw Original Select Box")]
         [Category("Debug")]
         [Display(Order = 1)]

--- a/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
+++ b/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="p3rpc.commonmodutils" Version="1.7.0" />
-    <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.7.3" />
+    <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.7.5" />
     <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
     <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0" />
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />


### PR DESCRIPTION
Updates `p3rpc.nativetypes` in the project file to 1.7.5, which redefines the `FColor` fields that define the camp character outline as `FLinearColor` and added the ability to edit them