### PR TITLE
Pinkification

### DIFF
--- a/code/p3rpc.femc/p3rpc.femc/Components/Camp.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/Camp.cs
@@ -2006,6 +2006,7 @@ namespace p3rpc.femc.Components
     public class CampSystem : ModuleAsmInlineColorEdit<FemcContext>
     {
         private string UCmpSystemDraw_GetMenuColors_SIG = "43 8B 94 ?? ?? ?? ?? ?? 41 0F 28 D4";
+        private string UCmpSystemDraw_DrawUnhighlightedMenuOptionsStart_SIG = "B9 00 9F 3E 04";
         private string UCmpSystemDraw_DrawUnhighlightedMenuOptions_SIG = "48 8B C4 48 89 58 ?? 44 89 48 ?? 44 89 40 ?? 55 56 57 41 54 41 55 41 56 41 57 48 81 EC 40 01 00 00";
         private string UCmpSystemDraw_GetMenuColorNoSelect_SIG = "4D 8B 24 ?? 83 FB 06"; // or edi, 0x13389500
         //private string UCmpSystemDraw_GetMenuColorNoSelect_SIG = "81 CF 00 95 38 13"; // or edi, 0x13389500
@@ -2082,6 +2083,10 @@ namespace p3rpc.femc.Components
         private CampCommon _campCommon;
         public unsafe CampSystem(FemcContext context, Dictionary<string, ModuleBase<FemcContext>> modules) : base(context, modules)
         {
+            _context._utils.SigScan(UCmpSystemDraw_DrawUnhighlightedMenuOptionsStart_SIG, "UCmpSystemDraw::DrawUnhighlightedMenuOptionsStart", _context._utils.GetDirectAddress, addr =>
+            {
+                _asmMemWrites.Add(new AddressToMemoryWrite(_context._memory, (nuint)addr, addr => _context._memory.Write(addr + 1, _context._config.CampSystemStartFadeColor.ToU32IgnoreAlpha())));
+            });
             _context._utils.SigScan(UCmpSystemDraw_DrawUnhighlightedMenuOptions_SIG, "UCmpSystemDraw::DrawUnhighlightedMenuOptions", _context._utils.GetDirectAddress, addr => _drawUnhighlightOptions = _context._utils.MakeHooker<UCmpSystemDraw_DrawUnhighlightedMenuOptions>(UCmpSystemDraw_DrawUnhighlightedMenuOptionsImpl, addr));
             _context._utils.SigScan(UCmpSystemDraw_GetMenuColors_SIG, "UCmpSystemDraw_MenuOptionColors", trans => (nuint)(_context._baseAddress + *(int*)(_context._baseAddress + trans + 4)), addr => _systemOptionColors = (FSprColor*)addr);
             _context._utils.SigScan(UCmpSystemDraw_GetMenuColorNoSelect_SIG, "UCmpSystemDraw::GetMenuColorNoSelect", _context._utils.GetDirectAddress, addr =>

--- a/code/p3rpc.femc/p3rpc.femc/Components/EndGameSelections.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/EndGameSelections.cs
@@ -1,0 +1,161 @@
+﻿using p3rpc.commonmodutils;
+using Reloaded.Hooks.Definitions;
+using Reloaded.Hooks.Definitions.Enums;
+
+namespace p3rpc.femc.Components
+{
+    class EndGameSelections : ModuleAsmInlineColorEdit<FemcContext>
+    {
+        private string AUIEndGameSelectionDraw_EndFirstSelectionGlowColor_SIG = "0F B6 C3 66 44 0F 6E F0";
+        private string AUIEndGameSelectionDraw_EndFirstSelectionFontColor_SIG = "41 81 C9 00 FF 00 18";
+        private string AUIEndGameSelectionDraw_EndFirstSelectionBackgroundColor_SIG = "41 81 C9 00 FC F3 F0";
+
+        private string AUIEndGameSelectionDraw_EndPreSecondSelectionSubsTint1_SIG = "C7 85 ?? ?? ?? ?? 97 15 01 FF F3 0F 58 35";
+        private string AUIEndGameSelectionDraw_EndPreSecondSelectionSubsTint2_SIG = "C7 85 ?? ?? ?? ?? 97 15 01 FF E8";
+        private string AUIEndGameSelectionDraw_EndPreSecondSelectionSubsTint3_SIG = "C7 85 ?? ?? ?? ?? B7 44 01 FF";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionGlowColor1_SIG = "E8 ?? ?? ?? ?? C6 44 24 ?? 24 0F 57 DB C6 44 24 ?? 04 41 0F 28 D0 F3 0F 59 C6 0F 28 CF 48 8B CE F3 0F 2C C0 F3 0F 10 05 ?? ?? ?? ?? 88 45 ?? 48 8B 87 ?? ?? ?? ?? 48 89 44 24 ?? 48 8D 45 ?? F3 44 0F 11 4C 24 ?? F3 0F 11 44 24 ?? F3 44 0F 11 54 24";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionGlowColor2_SIG = "E8 ?? ?? ?? ?? C6 44 24 ?? 24 0F 57 DB C6 44 24 ?? 04 41 0F 28 D0 F3 0F 59 C6 0F 28 CF 48 8B CE F3 0F 2C C0 F3 0F 10 05 ?? ?? ?? ?? 88 45 ?? 48 8B 87 ?? ?? ?? ?? 48 89 44 24 ?? 48 8D 45 ?? F3 44 0F 11 4C 24 ?? F3 0F 11 44 24 ?? F3 0F 10 05";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionFirstOptionFontGlowColor1_SIG = "66 0F 6E C0 0F 5B C0 F3 0F 11 45 ?? F3 0F 59 05";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionFirstOptionFontGlowColor2_SIG = "F3 0F 11 44 24 ?? F3 0F 2C C1 0F 28 CF";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionFirstOptionFontGlowColor3_SIG = "0F 28 CE 88 45 ?? 48 8B 87 ?? ?? ?? ?? 48 89 44 24 ?? 48 8D 45 ?? F3 44 0F 11 4C 24 ?? F3 44 0F 11 54 24 ?? F3 44 0F 11 54 24 ?? C7 44 24 ?? 06 00 00 00";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionSecondOptionFontGlowColor1_SIG = "0F 28 D7 0F 28 CE 41 0F 28 C0";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionSecondOptionFontGlowColor2_SIG = "0F 28 D7 F3 41 0F 59 C0 0F 28 CE";
+        private string AUIEndGameSelectionDraw_EndSecondSelectionSecondOptionFontGlowColor3_SIG = "0F 28 D7 F3 41 0F 2C C4";
+
+        private IAsmHook _endFirstSelectionGlowColor;
+        private IAsmHook _endSecondSelectionGlowColor1;
+        private IAsmHook _endSecondSelectionGlowColor2;
+        private IAsmHook _endSecondSelectionFirstOptionFontGlowColor1;
+        private IAsmHook _endSecondSelectionFirstOptionFontGlowColor2;
+        private IAsmHook _endSecondSelectionFirstOptionFontGlowColor3;
+        private IAsmHook _endSecondSelectionSecondOptionFontGlowColor1;
+        private IAsmHook _endSecondSelectionSecondOptionFontGlowColor2;
+        private IAsmHook _endSecondSelectionSecondOptionFontGlowColor3;
+        public unsafe EndGameSelections(FemcContext context, Dictionary<string, ModuleBase<FemcContext>> modules) : base(context, modules)
+        {
+
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndFirstSelectionGlowColor_SIG, "AUIEndGameSelectionDraw::EndFirstSelectionGlowColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp + 0xd0], ${_context._config.EndGameFirstGlowColor.B:X}",
+                    $"mov byte [rbp + 0xd1], ${_context._config.EndGameFirstGlowColor.G:X}",
+                    $"mov byte [rbp + 0xd2], ${_context._config.EndGameFirstGlowColor.R:X}"
+                };
+                _endFirstSelectionGlowColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndFirstSelectionFontColor_SIG, "AUIEndGameSelectionDraw::EndFirstSelectionFontColor", _context._utils.GetDirectAddress, addr =>
+            {
+                _asmMemWrites.Add(new AddressToMemoryWrite(_context._memory, (nuint)addr, addr => _context._memory.Write(addr + 3, _context._config.EndGameFirstFontColor.ToU32IgnoreAlpha())));
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndFirstSelectionBackgroundColor_SIG, "AUIEndGameSelectionDraw::EndFirstSelectionBackgroundColor", _context._utils.GetDirectAddress, addr =>
+            {
+                _asmMemWrites.Add(new AddressToMemoryWrite(_context._memory, (nuint)addr, addr => _context._memory.Write(addr + 3, _context._config.EndGameFirstBGColor.ToU32IgnoreAlpha())));
+            });
+
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndPreSecondSelectionSubsTint1_SIG, "AUIEndGameSelectionDraw::EndPreSecondSelectionSubsTint1", _context._utils.GetDirectAddress, addr =>
+            {
+                _asmMemWrites.Add(new AddressToMemoryWrite(_context._memory, (nuint)addr, addr => _context._memory.Write(addr + 6, _context._config.EndGamePreSecondFontTint1.ToU32ARGB())));
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndPreSecondSelectionSubsTint2_SIG, "AUIEndGameSelectionDraw::EndPreSecondSelectionSubsTint2", _context._utils.GetDirectAddress, addr =>
+            {
+                _asmMemWrites.Add(new AddressToMemoryWrite(_context._memory, (nuint)addr, addr => _context._memory.Write(addr + 6, _context._config.EndGamePreSecondFontTint1.ToU32ARGB())));
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndPreSecondSelectionSubsTint3_SIG, "AUIEndGameSelectionDraw::EndPreSecondSelectionSubsTint3", _context._utils.GetDirectAddress, addr =>
+            {
+                _asmMemWrites.Add(new AddressToMemoryWrite(_context._memory, (nuint)addr, addr => _context._memory.Write(addr + 6, _context._config.EndGamePreSecondFontTint2.ToU32ARGB())));
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionGlowColor1_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionGlowColor1", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x78], ${_context._config.EndGameSecondGlowColor1.B:X}",
+                    $"mov byte [rbp - 0x77], ${_context._config.EndGameSecondGlowColor1.G:X}",
+                    $"mov byte [rbp - 0x76], ${_context._config.EndGameSecondGlowColor1.R:X}"
+                };
+                _endSecondSelectionGlowColor1 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionGlowColor2_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionGlowColor2", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x74], ${_context._config.EndGameSecondGlowColor2.B:X}",
+                    $"mov byte [rbp - 0x73], ${_context._config.EndGameSecondGlowColor2.G:X}",
+                    $"mov byte [rbp - 0x72], ${_context._config.EndGameSecondGlowColor2.R:X}"
+                };
+                _endSecondSelectionGlowColor2 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionFirstOptionFontGlowColor1_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionFirstOptionFontGlowColor1", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rsp + 0x74], ${_context._config.EndGameSecondFontGlowColor1.B:X}",
+                    $"mov byte [rsp + 0x75], ${_context._config.EndGameSecondFontGlowColor1.G:X}",
+                    $"mov byte [rsp + 0x76], ${_context._config.EndGameSecondFontGlowColor1.R:X}"
+                };
+                _endSecondSelectionFirstOptionFontGlowColor1 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionFirstOptionFontGlowColor2_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionFirstOptionFontGlowColor2", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x68], ${_context._config.EndGameSecondFontGlowColor2.B:X}",
+                    $"mov byte [rbp - 0x67], ${_context._config.EndGameSecondFontGlowColor2.G:X}",
+                    $"mov byte [rbp - 0x66], ${_context._config.EndGameSecondFontGlowColor2.R:X}"
+                };
+                _endSecondSelectionFirstOptionFontGlowColor2 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionFirstOptionFontGlowColor3_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionFirstOptionFontGlowColor3", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x70], ${_context._config.EndGameSecondFontGlowColor3.B:X}",
+                    $"mov byte [rbp - 0x6f], ${_context._config.EndGameSecondFontGlowColor3.G:X}",
+                    $"mov byte [rbp - 0x6e], ${_context._config.EndGameSecondFontGlowColor3.R:X}"
+                };
+                _endSecondSelectionFirstOptionFontGlowColor3 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionSecondOptionFontGlowColor1_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionSecondOptionFontGlowColor1", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x80], ${_context._config.EndGameSecondFontGlowColor1.B:X}",
+                    $"mov byte [rbp - 0x7f], ${_context._config.EndGameSecondFontGlowColor1.G:X}",
+                    $"mov byte [rbp - 0x7e], ${_context._config.EndGameSecondFontGlowColor1.R:X}"
+                };
+                _endSecondSelectionSecondOptionFontGlowColor1 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionSecondOptionFontGlowColor2_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionSecondOptionFontGlowColor2", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x64], ${_context._config.EndGameSecondFontGlowColor2.B:X}",
+                    $"mov byte [rbp - 0x63], ${_context._config.EndGameSecondFontGlowColor2.G:X}",
+                    $"mov byte [rbp - 0x62], ${_context._config.EndGameSecondFontGlowColor2.R:X}"
+                };
+                _endSecondSelectionSecondOptionFontGlowColor2 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIEndGameSelectionDraw_EndSecondSelectionSecondOptionFontGlowColor3_SIG, "AUIEndGameSelectionDraw::EndSecondSelectionSecondOptionFontGlowColor3", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov byte [rbp - 0x60], ${_context._config.EndGameSecondFontGlowColor3.B:X}",
+                    $"mov byte [rbp - 0x5f], ${_context._config.EndGameSecondFontGlowColor3.G:X}",
+                    $"mov byte [rbp - 0x5e], ${_context._config.EndGameSecondFontGlowColor3.R:X}"
+                };
+                _endSecondSelectionSecondOptionFontGlowColor3 = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+        }
+
+        public override void Register() { }
+    }
+}

--- a/code/p3rpc.femc/p3rpc.femc/Components/Guidance.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/Guidance.cs
@@ -1,0 +1,108 @@
+﻿using p3rpc.commonmodutils;
+using Reloaded.Hooks.Definitions;
+using Reloaded.Hooks.Definitions.Enums;
+
+namespace p3rpc.femc.Components
+{
+    class Guidance : ModuleBase<FemcContext>
+    {
+        private string AUIGuidanceDraw_GuidanceLeftFadeMainColor_SIG = "E8 ?? ?? ?? ?? 48 8B 8F ?? ?? ?? ?? 8B E8 E8";
+        private string AUIGuidanceDraw_GuidanceMainColor_SIG = "E8 ?? ?? ?? ?? 41 B8 06 00 00 00 48 8D 54 24 ?? 48 8B CE";
+        private string AUIGuidanceDraw_GuidanceBGSquareColor = "E8 ?? ?? ?? ?? F3 0F 10 86 ?? ?? ?? ?? 48 8D 8E";
+        private string AUIGuidanceDraw_GuidanceExclamationGlowColor = "E8 ?? ?? ?? ?? 48 8B 54 24 ?? 48 8B CB 89 86";
+        private string AUIGuidanceDraw_GuidanceExclamationMainColor = "E8 ?? ?? ?? ?? 4C 8B 74 24 ?? 48 8D 8E ?? ?? ?? ?? 89 86";
+        private string AUIGuidanceDraw_NewGuidanceExclamationGlowColor = "E8 ?? ?? ?? ?? F3 44 0F 10 15 ?? ?? ?? ?? 48 8B CB";
+        private string AUIGuidanceDraw_NewGuidanceExclamationMainColor = "E8 ?? ?? ?? ?? 48 8B 54 24 ?? 48 8D 8E ?? ?? ?? ?? 89 86";
+
+        private IAsmHook _guidanceLeftFadeMainColor;
+        private IAsmHook _guidanceMainColor;
+        private IAsmHook _guidanceBGSquareColor;
+        private IAsmHook _guidanceExclamationGlowColor;
+        private IAsmHook _guidanceExclamationMainColor;
+        private IAsmHook _newGuidanceExclamationGlowColor;
+        private IAsmHook _newGuidanceExclamationMainColor;
+        public unsafe Guidance(FemcContext context, Dictionary<string, ModuleBase<FemcContext>> modules) : base(context, modules)
+        {
+
+            _context._utils.SigScan(AUIGuidanceDraw_GuidanceLeftFadeMainColor_SIG, "AUIGuidanceDraw::GuidanceLeftFadeMainColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceMainBGColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceMainBGColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceMainBGColor.R:X}"
+                };
+                _guidanceLeftFadeMainColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIGuidanceDraw_GuidanceMainColor_SIG, "AUIGuidanceDraw::GuidanceMainColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceMainBGColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceMainBGColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceMainBGColor.R:X}"
+                };
+                _guidanceMainColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIGuidanceDraw_GuidanceBGSquareColor, "AUIGuidanceDraw::GuidanceBGSquareColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceSquareColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceSquareColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceSquareColor.R:X}"
+                };
+                _guidanceBGSquareColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIGuidanceDraw_GuidanceExclamationGlowColor, "AUIGuidanceDraw::GuidanceExclamationGlowColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceExclamationGlowColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceExclamationGlowColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceExclamationGlowColor.R:X}"
+                };
+                _guidanceExclamationGlowColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIGuidanceDraw_GuidanceExclamationMainColor, "AUIGuidanceDraw::GuidanceExclamationMainColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceExclamationMainColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceExclamationMainColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceExclamationMainColor.R:X}"
+                };
+                _guidanceExclamationMainColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIGuidanceDraw_NewGuidanceExclamationGlowColor, "AUIGuidanceDraw::NewGuidanceExclamationGlowColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceExclamationGlowColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceExclamationGlowColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceExclamationGlowColor.R:X}"
+                };
+                _newGuidanceExclamationGlowColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+            _context._utils.SigScan(AUIGuidanceDraw_NewGuidanceExclamationMainColor, "AUIGuidanceDraw::NewGuidanceExclamationMainColor", _context._utils.GetDirectAddress, addr =>
+            {
+                string[] function =
+                {
+                    "use64",
+                    $"mov r8b, ${_context._config.GuidanceExclamationMainColor.B:X}",
+                    $"mov dl, ${_context._config.GuidanceExclamationMainColor.G:X}",
+                    $"mov cl, ${_context._config.GuidanceExclamationMainColor.R:X}"
+                };
+                _newGuidanceExclamationMainColor = _context._hooks.CreateAsmHook(function, addr, AsmHookBehaviour.ExecuteFirst).Activate();
+            });
+        }
+
+        public override void Register() { }
+    }
+}

--- a/code/p3rpc.femc/p3rpc.femc/Components/PersonaStatus.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Components/PersonaStatus.cs
@@ -928,9 +928,9 @@ namespace p3rpc.femc.Components
                     var personaHelpPos = self->TextLayoutDataTable->GetLayoutDataTableEntry(4); // DT_UILayout_PersonaStatusText
                     //var personaHelpRowOffset = self->TextPosRowLayoutDataTable->GetLayoutDataTableEntry(3); // crashes (nullptr) - layout table made at runtime from data table
                     var personaHelpRowOffset = _getTextPosRow(self, 3); // DT_UILayout_PersonaStatusTextPosRow 
-                    var loreDescShadowColor = ConfigColor.ToFColorBPWithAlpha(ConfigColor.MellodiColorDark1, loreTitleOpacity);
+                    var loreDescShadowColor = ConfigColor.ToFColorWithAlpha(ConfigColor.MellodiColorDark1, loreTitleOpacity);
                     _drawLoreDescription(fx + 5, fy + 2, 0, personaHelpPos->position.X, personaHelpPos->position.Y, loreDescShadowColor, self->pCurrentPersona->Id, self->baseObj.QueueId, 1, 0);
-                    var loreDescFgColor = ConfigColor.ToFColorBPWithAlpha(_context.ColorWhite, loreTitleOpacity);
+                    var loreDescFgColor = ConfigColor.ToFColorWithAlpha(_context.ColorWhite, loreTitleOpacity);
                     _drawLoreDescription(fx, fy, 0, personaHelpPos->position.X, personaHelpPos->position.Y, loreDescFgColor, self->pCurrentPersona->Id, self->baseObj.QueueId, 1, 0);
                 } else
                 {

--- a/code/p3rpc.femc/p3rpc.femc/Config.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Config.cs
@@ -902,6 +902,11 @@ namespace p3rpc.femc.Configuration
         [DefaultValue(true)]
         public bool EnableCommunity { get; set; } = true;
 
+        [DisplayName("Enable Guidance")]
+        [Category("UI Components")]
+        [Display(Order = 175)]
+        [DefaultValue(true)]
+        public bool EnableGuidance { get; set; } = true;
 
         [DisplayName("Mail Icon: Outer Color")]
         [Category("UI Colors")]
@@ -2901,7 +2906,55 @@ namespace p3rpc.femc.Configuration
         
         [DisplayName("Camp Config: Character Outline")]
         public ConfigColor EditConfigFillColor { get; set; } = new ConfigColor(0xff, 0xd7, 0x9d, 0xff);
-        
+
+        [DisplayName("Town Map: Town Info detail highlighted arrows")]
+        public ConfigColor TownMapHighlightedArrows { get; set; } = ConfigColor.Blue;
+
+        [DisplayName("Camp: System Menu Item starting fade animation color")]
+        public ConfigColor CampSystemStartFadeColor { get; set; } = new ConfigColor(0x9f, 0x04, 0x38, 0xff);
+
+        [DisplayName("Guidance: Guidance elements main background color")]
+        public ConfigColor GuidanceMainBGColor { get; set; } = new ConfigColor(0x48, 0x44, 0x46, 0xff);
+
+        [DisplayName("Guidance: Guidance elements squared background color")]
+        public ConfigColor GuidanceSquareColor { get; set; } = new ConfigColor(0x72, 0x6c, 0x6e, 0xff);
+
+        [DisplayName("Guidance: Guidance exclamation glow color")]
+        public ConfigColor GuidanceExclamationGlowColor { get; set; } = new ConfigColor(0xff, 0x00, 0x6a, 0xff);
+
+        [DisplayName("Guidance: Guidance exclamation main color")]
+        public ConfigColor GuidanceExclamationMainColor { get; set; } = new ConfigColor(0xfc, 0xbb, 0xd6, 0xff);
+
+        [DisplayName("End Game Selections: First selection background glow color")]
+        public ConfigColor EndGameFirstGlowColor { get; set; } = new ConfigColor(0x8f, 0x00, 0x34, 0xff);
+
+        [DisplayName("End Game Selections: First selection font color")]
+        public ConfigColor EndGameFirstFontColor { get; set; } = new ConfigColor(0xff, 0x00, 0x62, 0xff);
+
+        [DisplayName("End Game Selections: First selection background color")]
+        public ConfigColor EndGameFirstBGColor { get; set; } = new ConfigColor(0xfc, 0xf0, 0xf6, 0xff);
+
+        [DisplayName("End Game Selections: Subs font tint before second selection 1")]
+        public ConfigColor EndGamePreSecondFontTint1 { get; set; } = new ConfigColor(0x97, 0x01, 0x38, 0xff);
+
+        [DisplayName("End Game Selections: Subs font tint before second selection 2")]
+        public ConfigColor EndGamePreSecondFontTint2 { get; set; } = new ConfigColor(0xb7, 0x01, 0x4a, 0xff);
+
+        [DisplayName("End Game Selections: Second selection glow color 1")]
+        public ConfigColor EndGameSecondGlowColor1 { get; set; } = new ConfigColor(0x9d, 0x3d, 0x62, 0xff);
+
+        [DisplayName("End Game Selections: Second selection glow color 2")]
+        public ConfigColor EndGameSecondGlowColor2 { get; set; } = new ConfigColor(0xcd, 0x00, 0x4b, 0xff);
+
+        [DisplayName("End Game Selections: Second selection font glow color 1")]
+        public ConfigColor EndGameSecondFontGlowColor1 { get; set; } = new ConfigColor(0xfe, 0x55, 0x96, 0xff);
+
+        [DisplayName("End Game Selections: Second selection font glow color 2")]
+        public ConfigColor EndGameSecondFontGlowColor2 { get; set; } = new ConfigColor(0xfe, 0x14, 0x6e, 0xff);
+
+        [DisplayName("End Game Selections: Second selection font glow color 3")]
+        public ConfigColor EndGameSecondFontGlowColor3 { get; set; } = new ConfigColor(0xff, 0x12, 0x75, 0xff);
+
         /*[DisplayName("Draw Original Select Box")]
         [Category("Debug")]
         [Display(Order = 1)]

--- a/code/p3rpc.femc/p3rpc.femc/Mod.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Mod.cs
@@ -222,6 +222,7 @@ namespace p3rpc.femc
 				_modRuntime.AddModule<MsgWindowAssist>();
 				_modRuntime.AddModule<MsgWindowSystem>();
 				_modRuntime.AddModule<GenericSelect>();
+				_modRuntime.AddModule<EndGameSelections>();
 			}
 			if (_configuration.EnableMindMessageBox)
 			{
@@ -276,6 +277,7 @@ namespace p3rpc.femc
 				_modRuntime.AddModule<LocalizationStaffRoll>();
 				//_modRuntime.AddModule<StaffRoll>();
 			}
+			if (_configuration.EnableGuidance) _modRuntime.AddModule<Guidance>();
 			if (_configuration.EnableWipe) _modRuntime.AddModule<Wipe>();
 			if (_configuration.EnableItemList) _modRuntime.AddModule<ItemList>();
 			if (_configuration.EnableCommunity) _modRuntime.AddModule<Cmmu>();


### PR DESCRIPTION
Camp Menu:
- Pinkified System fade animation of the submenu options
- Fixed issue with Persona Status lore making it show an incorrect blue fade effect

Guidance:
- Pinkified blueish gray background colors
- Pinkified exclamation that shows up sometimes in guidance elements

TownMap:
- Fixed generic shop icon color being blue tinted
- Up/down/left/right arrows of location details are now blue

Endgame cinematic:
- Pinkified choices through the whole cinematic
- Pinkified subs just before the second in-game choice

That's all :glorpfeettrue: