### PR TITLE
Update p3rpc.nativetypes to 1.8.1

### DIFF
--- a/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
+++ b/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="p3rpc.commonmodutils" Version="1.7.0" />
-    <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.8.0" />
+    <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.8.1" />
     <PackageReference Include="Reloaded.Memory" Version="9.4.2" />
     <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0" />
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />


### PR DESCRIPTION
Uses nativetypes 1.8.1 instead of 1.8.0, which changed the bustup definition that broke backwards compatibility with nativetypes 1.7.x and earlier (specifically UBustupObject->FieldB0). This change was reverted in 1.8.1.