### PR TITLE
Remove classconstructor from dependencies

### DIFF
--- a/code/p3rpc.femc/p3rpc.femc/Context.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Context.cs
@@ -1,5 +1,4 @@
-﻿using p3rpc.classconstructor.Interfaces;
-using p3rpc.commonmodutils;
+﻿using p3rpc.commonmodutils;
 using p3rpc.femc.Configuration;
 using Reloaded.Hooks.ReloadedII.Interfaces;
 // using Reloaded.Hooks.Definitions;
@@ -7,27 +6,25 @@ using Reloaded.Memory;
 using Reloaded.Memory.SigScan.ReloadedII.Interfaces;
 using Reloaded.Mod.Interfaces;
 using SharedScans.Interfaces;
+using UE.Toolkit.Core.Types.Unreal.Factories;
 using UE.Toolkit.Interfaces;
 
 namespace p3rpc.femc
 {
-    public class FemcContext : UnrealContext
+    public class FemcContext : UnrealToolkitContext
     {
         public new Config _config { get; set; } // hide original config
         public readonly ConfigColor ColorBlack = new ConfigColor(0x0, 0x0, 0x0, 0xff);
         public readonly ConfigColor ColorWhite = new ConfigColor(0xff, 0xff, 0xff, 0xff);
         public bool bIsAigis { get; init; }
         public bool bIsSteam { get; set; }
-       
-        public IUnrealMemory _toolkitMemory { get; private set; }
-        public IUnrealClasses _toolkitClasses { get; private set; }
-        public IUnrealObjects _toolkitObjects { get; private set; }
 
         public FemcContext(long baseAddress, IConfigurable config, ILogger logger, IStartupScanner startupScanner, 
             IReloadedHooks hooks, string modLocation, Utils utils, Memory memory, ISharedScans sharedScans, 
-            IClassMethods classMethods, IObjectMethods objectMethods, bool _bIsAigis,
-            IUnrealMemory toolkitMemory, IUnrealClasses toolkitClasses, IUnrealObjects toolkitObjects)
-            : base (baseAddress, config, logger, startupScanner, hooks, modLocation, utils, memory, sharedScans, classMethods, objectMethods) 
+            bool _bIsAigis, IUnrealMemory toolkitMemory, IUnrealClasses toolkitClasses, IUnrealObjects toolkitObjects,
+            IUnrealStrings toolkitStrings, IUnrealFactory toolkitFactory, IUnrealState toolkitState, IUnrealSpawning toolkitSpawning)
+            : base (baseAddress, config, logger, startupScanner, hooks, modLocation, utils, memory, sharedScans, 
+                toolkitStrings, toolkitObjects, toolkitMemory, toolkitClasses, toolkitFactory, toolkitState, toolkitSpawning) 
         {
             _config = (Config)config;
             bIsAigis = _bIsAigis;

--- a/code/p3rpc.femc/p3rpc.femc/Mod.cs
+++ b/code/p3rpc.femc/p3rpc.femc/Mod.cs
@@ -1,5 +1,4 @@
 ﻿using P3R.CostumeFramework.Interfaces;
-using p3rpc.classconstructor.Interfaces;
 using p3rpc.commonmodutils;
 using p3rpc.femc.Audio;
 using p3rpc.femc.Components;
@@ -14,6 +13,7 @@ using Ryo.Interfaces;
 using SharedScans.Interfaces;
 using System.Diagnostics;
 using Reloaded.Hooks.ReloadedII.Interfaces;
+using UE.Toolkit.Core.Types.Unreal.Factories;
 using UE.Toolkit.Interfaces;
 using UnrealEssentials.Interfaces;
 using static p3rpc.femc.Configuration.Config;
@@ -82,14 +82,15 @@ namespace p3rpc.femc
 			var sharedScans = GetDependency<ISharedScans>("Shared Scans");
 			Utils utils = new(startupScanner, _logger, _hooks, baseAddress, "Femc Project", System.Drawing.Color.Thistle, _configuration.DebugLogLevel);
 			var unrealEssentials = GetDependency<IUnrealEssentials>("Unreal Essentials");
-			var classMethods = GetDependency<IClassMethods>("Class Constructor (Class Methods)");
-            var objectMethods = GetDependency<IObjectMethods>("Class Constructor (Object Methods)");
-			var uObjects = GetDependency<IUnrealObjects>("UE Toolkit (IUObjects)");
-            var toolKit = GetDependency<IToolkit>("UE Toolkit (IToolkit");
+            var unrealToolkit = GetDependency<IToolkit>("UE Toolkit (IToolkit)");
             var unrealMemory = GetDependency<IUnrealMemory>("UE Toolkit (IUnrealMemory)");
             var unrealNames = GetDependency<IUnrealNames>("UE Toolkit (IUnrealNames)");
             var unrealClasses = GetDependency<IUnrealClasses>("UE Toolkit (IUnrealClasses)");
             var unrealObjects = GetDependency<IUnrealObjects>("UE Toolkit (IUnrealObjects)");
+            var unrealStrings = GetDependency<IUnrealStrings>("UE Toolkit (IUnrealStrings)");
+            var unrealFactory = GetDependency<IUnrealFactory>("UE Toolkit (IUnrealFactory)");
+            var unrealState = GetDependency<IUnrealState>("UE Toolkit (IUnrealState)");
+            var unrealSpawning = GetDependency<IUnrealSpawning>("UE Toolkit (IUnrealSpawning)");
             _costumeApi = GetDependency<ICostumeApi>("Costume Framework");
 
 			var ryo = GetDependency<IRyoApi>("Ryo Framework");
@@ -115,14 +116,15 @@ namespace p3rpc.femc
 
             _context = new(
 	            baseAddress, _configuration, _logger, startupScanner, _hooks, _modLoader.GetDirectoryForModId(_modConfig.ModId), 
-	            utils, memory, sharedScans, classMethods, objectMethods, bIsAigis, unrealMemory, unrealClasses, unrealObjects);
+	            utils, memory, sharedScans, bIsAigis, unrealMemory, unrealClasses, unrealObjects, unrealStrings,
+	            unrealFactory, unrealState, unrealSpawning);
 			_modRuntime = new(_context);
 			_musicManager = new MusicManager(_modLoader, _modConfig, _configuration, ryo, _logger, _context);
-            _armorData = new(_modLoader, _modConfig, _configuration, uObjects, toolKit, _context);
+            _armorData = new(_modLoader, _modConfig, _configuration, unrealObjects, unrealToolkit, _context);
 
             modName = _modConfig.ModName;
 			// Load Modules/assets
-			LoadEnabledAddons(unrealEssentials, ryo, toolKit);
+			LoadEnabledAddons(unrealEssentials, ryo, unrealToolkit);
 			InitializeModules();
 			_assetRedirector = new AssetRedirector(unrealNames, modName);
 			_assetRedirector.RedirectPlayerAssets();

--- a/code/p3rpc.femc/p3rpc.femc/ModConfig.json
+++ b/code/p3rpc.femc/p3rpc.femc/ModConfig.json
@@ -36,15 +36,6 @@
     },
     "GitHubDependencies": {
       "IdToConfigMap": {
-        "p3rpc.classconstructor": {
-          "Config": {
-            "UserName": "Rirurin",
-            "RepositoryName": "p3rpc.classconstructor",
-            "UseReleaseTag": true,
-            "AssetFileName": "Mod.zip"
-          },
-          "ReleaseMetadataName": "p3rpc.classconstructor.ReleaseMetadata.json"
-        },
         "p3rpc.nativetypes": {
           "Config": {
             "UserName": "Rirurin",
@@ -218,7 +209,6 @@
   },
   "IsUniversalMod": false,
   "ModDependencies": [
-    "p3rpc.classconstructor",
     "p3rpc.eventframework",
     "p3rpc.nativetypes",
     "P3R.CostumeFramework",

--- a/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
+++ b/code/p3rpc.femc/p3rpc.femc/p3rpc.femc.csproj
@@ -42,7 +42,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="p3rpc.commonmodutils" Version="1.8.2" />
+    <PackageReference Include="p3rpc.commonmodutils" Version="1.9.0" />
     <PackageReference Include="p3rpc.nativetypes.Interfaces" Version="1.8.1" />
     <PackageReference Include="Reloaded.Memory" Version="9.4.3" />
     <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0" />


### PR DESCRIPTION
Remove since it breaks UE4SS's NotifyOnNewObject and it wasn't being used for anything other than to pass as a parameter into construct the context object.